### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/modelcules/security/code-scanning/6](https://github.com/djleamen/modelcules/security/code-scanning/6)

To fix the problem, explicitly set the `permissions` block to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, since the workflow only checks out code, installs dependencies, builds, and runs tests, it only needs read access to repository contents. The best way to do this is to add a `permissions: contents: read` block at the top level of the workflow (just after the `name:` field and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
