### PR TITLE
Fix alkane hydrogen indexing bug, restore working lint setup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
+  },
+};

--- a/src/utils/moleculeParser.ts
+++ b/src/utils/moleculeParser.ts
@@ -162,7 +162,7 @@ async function parseIUPACName(iupacName: string, _allIdentifiers?: Partial<Chemi
 
   // Try to get SMILES from PubChem for complex molecules
   try {
-    const smiles = await getSmikesFromIUPAC(iupacName);
+    const smiles = await getSmilesFromIUPAC(iupacName);
     if (smiles) {
       return parseSMILES(smiles);
     }
@@ -191,7 +191,7 @@ async function parseIUPACName(iupacName: string, _allIdentifiers?: Partial<Chemi
 }
 
 // Helper function to get SMILES from IUPAC name using PubChem
-async function getSmikesFromIUPAC(iupacName: string): Promise<string | null> {
+async function getSmilesFromIUPAC(iupacName: string): Promise<string | null> {
   try {
     const url = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/${encodeURIComponent(iupacName)}/property/CanonicalSMILES/JSON`;
     const response = await fetch(url);
@@ -835,6 +835,7 @@ function createSimpleAlkane(length: number): Molecule3D {
       });
       
       bonds.push({ atomIndex1: i, atomIndex2: hydrogenId, bondType: 1 });
+      hydrogenId++;
     }
   }
   


### PR DESCRIPTION
## Testing done
- `npm ci`, `npm run build` (tsc + vite) — passes.
- `npm run lint` — previously failed outright: no ESLint config file existed anywhere in the repo, so the script could never run.
- Dev server smoke test — index and module entry serve correctly.
- Exercised `normalizeIdentifier` / `validateIdentifier` with edge cases (un-hyphenated CAS numbers, `CID:`/`CSID` prefixes, lowercase UNII/InChI/E-numbers) — all behave correctly.
- Exercised `parseMolecule` with a linear alkane SMILES (`CCCCCCC`) and verified atom ids and bond indices before/after the fix.

## Fixes
- **`createSimpleAlkane` hydrogen indexing bug:** `hydrogenId` was initialized but never incremented, so every hydrogen atom got the same id and every C–H bond pointed at the first hydrogen's index. Long-chain alkanes parsed from SMILES (e.g. `CCCCCCC`) rendered with all hydrogens bonded to one atom. Now each hydrogen gets a unique id and bonds connect correctly (verified: 23 unique ids, 16 unique H-bond targets for heptane). This was surfaced by ESLint's `prefer-const` flagging the variable as never reassigned.
- **Missing ESLint config:** added the standard Vite React-TS `.eslintrc.cjs` matching the plugins already in `devDependencies`, with `argsIgnorePattern: '^_'` to match the codebase's existing convention for intentionally unused parameters. `npm run lint` now passes with zero warnings.
- **Typo:** `getSmikesFromIUPAC` → `getSmilesFromIUPAC`.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_